### PR TITLE
clientのanalyze, build時のNODE_ENVをproductionにする

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.1",
   "license": "MPL-2.0",
   "scripts": {
-    "analyze": "cross-env NODE_ENV=development webpack --analyze",
+    "analyze": "cross-env NODE_ENV=production webpack --analyze",
     "prebuild": "rimraf ../dist",
-    "build": "cross-env NODE_ENV=development webpack",
+    "build": "cross-env NODE_ENV=production webpack",
     "develop": "cross-env NODE_ENV=development webpack serve"
   },
   "dependencies": {


### PR DESCRIPTION
## とりあえずバンドルサイズの内訳を確認してみる
```
"analyze": "cross-env NODE_ENV=development webpack --analyze"
```
がclientに用意されていたので実行してみると
![127 0 0 1_8888_](https://user-images.githubusercontent.com/63352797/144742287-6c79ac14-ec03-43ef-98ae-8fbc4a4250c8.png)
こんな感じになってた
`lodash.js`と`react-dom.development.js`が特に大きな割合を占めていることが分かる

## react-dom.development.jsを消す
もちろんdevelopmentには必要なので、production環境で含ませないようにしていく
```
"scripts": {
-    "analyze": "cross-env NODE_ENV=development webpack --analyze",
+    "analyze": "cross-env NODE_ENV=production webpack --analyze",
     "prebuild": "rimraf ../dist",
-    "build": "cross-env NODE_ENV=development webpack",
+    "build": "cross-env NODE_ENV=production webpack",
     "develop": "cross-env NODE_ENV=development webpack serve"
   },
```
こんな感じ
`NODE_ENV=development`とわざわざ明示してくれてたのでわかりやすかった