### PR TITLE
purgeオプションでjsxファイル内で指定されているスタイルのみバンドルするようにした

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   darkMode: false,
+  purge: ['./src/**/*.jsx']
 };


### PR DESCRIPTION
## tailwindのサイズを小さく
purge オプションにクラスを指定している`.jsx`のpathを指定していく
```
 module.exports = {
   darkMode: false,
+  purge: ['./src/**/*.jsx']
 };
```
