### PR TITLE
lodashで使っているメソッド部分だけバンドルするように

### DIFF
--- a/client/src/components/foundation/SoundWaveSVG/SoundWaveSVG.jsx
+++ b/client/src/components/foundation/SoundWaveSVG/SoundWaveSVG.jsx
@@ -1,4 +1,8 @@
-import _ from 'lodash';
+import map from 'lodash/map';
+import chunk from 'lodash/chunk';
+import max from 'lodash/max';
+import zip from 'lodash/zip';
+import mean from 'lodash/mean';
 import React from 'react';
 
 /**
@@ -14,20 +18,20 @@ async function calculate(data) {
     audioCtx.decodeAudioData(data.slice(0), resolve, reject);
   });
   // 左の音声データの絶対値を取る
-  const leftData = _.map(buffer.getChannelData(0), Math.abs);
+  const leftData = map(buffer.getChannelData(0), Math.abs);
   // 右の音声データの絶対値を取る
-  const rightData = _.map(buffer.getChannelData(1), Math.abs);
+  const rightData = map(buffer.getChannelData(1), Math.abs);
 
   // 左右の音声データの平均を取る
-  const normalized = _.map(_.zip(leftData, rightData), _.mean);
+  const normalized = map(zip(leftData, rightData), mean);
   // 100 個の chunk に分ける
-  const chunks = _.chunk(normalized, Math.ceil(normalized.length / 100));
+  const chunks = chunk(normalized, Math.ceil(normalized.length / 100));
   // chunk ごとに平均を取る
-  const peaks = _.map(chunks, _.mean);
+  const peaks = map(chunks, mean);
   // chunk の平均の中から最大値を取る
-  const max = _.max(peaks);
+  const chunk_max = max(peaks);
 
-  return { max, peaks };
+  return { max: chunk_max, peaks };
 }
 
 /**


### PR DESCRIPTION
## lodash.jsを消す（小さく）
どこかでlodashをまるごとimportしてると想像できたので、`ctrl + shift + f`でlodashをimportしているところを探してみる
↓
`SoundWaveSVG.jsx`で
```
import _ from 'lodash';
```
をやっていたことが判明した

使っているメソッド部分だけバンドルするように
```
-import _ from 'lodash';
+import map from 'lodash/map';
+import chunk from 'lodash/chunk';
+import max from 'lodash/max';
```
と書き換えた。
なお、`transform-imports`を用いることで
```
import { map, chunk, max } from 'lodash'
```
で同じことが実現できる。